### PR TITLE
Update MAM

### DIFF
--- a/routes/MAM
+++ b/routes/MAM
@@ -10,7 +10,7 @@ DCC
 Milkie
 90 MiM: 3 months account age.
 90 OBS: 100GB upload. 3 months account age.
-OPS
+365 OPS: 1 year account age.
 OTW: 1 other tracker profile.
 PxC
 180 PxHD: 2 other tracker profiles. 6 months account age.


### PR DESCRIPTION
OPS requieres a 1 year old account. Changed the file to reflect that. Solves https://github.com/inviteroute/graph/issues/4. 