### PR TITLE
Update MAM Invite Forum Requirements

### DIFF
--- a/trackers
+++ b/trackers
@@ -75,7 +75,7 @@ KeepFRDS: KeepFRDS
 LB: LearnBits
 LeagueHD: LeagueHD
 LzTr: LzTr | Invite forum unlocks with Power User user class: 25GB upload, 1.05 ratio, 5 torrents uploaded, 2 weeks account age.
-MAM: MyAnonaMouse |28 Invite forum unlocks with Power User user class: 25GB upload, 2.0 ratio, 4 weeks account age.<br>Some threads additionally require VIP, purchased with bonus points.
+MAM: MyAnonaMouse |28 Invite forum unlocks with Power User user class: 1TB upload, 2.0 ratio, 6 months account age.<br>Some threads additionally require VIP, purchased with bonus points.
 MDU: MONIKADESIGN
 Milkie: Milkie
 MiM: Magicis.me


### PR DESCRIPTION
MAM now requires 1TB upload and 6 months account age to unlock the invite forum